### PR TITLE
🧪 [testing] add StatsService tests

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,7 +10,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "test": "node --test --experimental-strip-types --experimental-loader=./test-loader.js services/__tests__/*.test.ts"
   },
   "dependencies": {
     "@radix-ui/react-avatar": "^1.1.11",

--- a/apps/web/services/__tests__/StatsService.test.ts
+++ b/apps/web/services/__tests__/StatsService.test.ts
@@ -1,0 +1,51 @@
+import { test, describe } from "node:test";
+import assert from "node:assert";
+
+// @ts-ignore
+import { _mockCalls } from "stats.js";
+import { StatsService } from "../StatsService.ts";
+
+describe("StatsService", () => {
+    test("should initialize with default panel and styles", () => {
+        // Clear previous calls
+        _mockCalls.showPanel.length = 0;
+
+        const service = new StatsService();
+        const dom = service.getDom();
+
+        assert.strictEqual(_mockCalls.showPanel.length, 1);
+        assert.strictEqual(_mockCalls.showPanel[0][0], 0);
+
+        assert.strictEqual(dom.style.position, "absolute");
+        assert.strictEqual(dom.style.top, "0");
+        assert.strictEqual(dom.style.left, "0");
+    });
+
+    test("begin() should call stats.begin()", () => {
+        _mockCalls.begin.length = 0;
+        const service = new StatsService();
+        service.begin();
+        assert.strictEqual(_mockCalls.begin.length, 1);
+    });
+
+    test("end() should call stats.end()", () => {
+        _mockCalls.end.length = 0;
+        const service = new StatsService();
+        service.end();
+        assert.strictEqual(_mockCalls.end.length, 1);
+    });
+
+    test("getDom() should return the stats DOM element", () => {
+        const service = new StatsService();
+        const dom = service.getDom();
+        assert.ok(dom);
+        assert.ok(dom.style);
+    });
+
+    test("dispose() should remove the DOM element", () => {
+        _mockCalls.remove.length = 0;
+        const service = new StatsService();
+        service.dispose();
+        assert.strictEqual(_mockCalls.remove.length, 1);
+    });
+});

--- a/apps/web/test-loader.js
+++ b/apps/web/test-loader.js
@@ -1,0 +1,48 @@
+import { pathToFileURL } from 'node:url';
+
+const statsMockUrl = 'data:text/javascript,' + encodeURIComponent(`
+  const mockCalls = {
+    showPanel: [],
+    begin: [],
+    end: [],
+    remove: []
+  };
+
+  export const _mockCalls = mockCalls;
+
+  export default class Stats {
+    constructor() {
+      this.dom = {
+        style: {},
+        remove: () => {
+          mockCalls.remove.push([]);
+        }
+      };
+    }
+    showPanel(panel) {
+      mockCalls.showPanel.push([panel]);
+    }
+    begin() {
+      mockCalls.begin.push([]);
+    }
+    end() {
+      mockCalls.end.push([]);
+    }
+  }
+`);
+
+export function resolve(specifier, context, nextResolve) {
+  if (specifier === 'stats.js') {
+    return {
+      shortCircuit: true,
+      url: statsMockUrl
+    };
+  }
+  if (specifier === '@/types') {
+    return {
+      shortCircuit: true,
+      url: 'data:text/javascript,export {}'
+    };
+  }
+  return nextResolve(specifier, context);
+}


### PR DESCRIPTION
### 🎯 What: The testing gap addressed
The `StatsService` was missing test coverage. This PR adds a comprehensive unit test suite to verify its functionality.

### 📊 Coverage: What scenarios are now tested
- **Initialization**: Verifies `stats.js` is instantiated and configured with the correct panel (0: fps) and DOM styles (absolute positioning).
- **Frame measurement**: Verifies `begin()` and `end()` correctly call the underlying `stats.js` methods.
- **DOM Access**: Verifies `getDom()` returns the correct element.
- **Disposal**: Verifies `dispose()` correctly removes the DOM element.

### ✨ Result: The improvement in test coverage
- Added unit tests for `StatsService.ts`.
- Established a lightweight testing infrastructure for `apps/web` using the Node.js built-in test runner, which works within the environment's network constraints.


---
*PR created automatically by Jules for task [11428024720893873338](https://jules.google.com/task/11428024720893873338) started by @osama-ata*