### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix Information Leakage via Error Messages

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-18 - Information Leakage via Error Messages
+**Vulnerability:** HTTPException detail strings exposed raw exception details `str(e)` in error responses.
+**Learning:** This occurred due to directly passing caught exception details to the client instead of generic error messages, leading to potential exposure of internal systems, paths, or logic (stack traces/errors).
+**Prevention:** Always log the detailed error internally (`logger.error()`) and return generic error messages to the client when raising HTTPExceptions.

--- a/apps/api/app/api/endpoints/analyze.py
+++ b/apps/api/app/api/endpoints/analyze.py
@@ -20,4 +20,4 @@ async def analyze_ifc(file: UploadFile = File(...)):
         }
     except Exception as e:
         logger.error(f"Error processing IFC file: {str(e)}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise HTTPException(status_code=500, detail="An internal error occurred while processing the file.")

--- a/apps/api/app/api/endpoints/rules.py
+++ b/apps/api/app/api/endpoints/rules.py
@@ -1,9 +1,11 @@
 import json
+import logging
 import os
 from functools import lru_cache
 from fastapi import APIRouter, HTTPException
 
 router = APIRouter()
+logger = logging.getLogger(__name__)
 
 RULES_FILE_PATH = os.path.join(
     os.path.dirname(os.path.dirname(os.path.dirname(__file__))),
@@ -34,4 +36,5 @@ def get_rules():
     except Exception as e:
         # Clear cache in case of transient errors
         get_cached_rules.cache_clear()
-        raise HTTPException(status_code=500, detail=f"Error reading rules data: {str(e)}")
+        logger.error(f"Error reading rules data: {str(e)}")
+        raise HTTPException(status_code=500, detail="An internal error occurred while reading rules data.")


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: FastAPI endpoints (`analyze_ifc` and `get_rules`) were explicitly raising `HTTPException` objects and passing raw exception strings `str(e)` to the client, leading to Information Leakage (CWE-209).
🎯 Impact: This allowed attackers or clients to see internal exception details or traceback structures, which could expose file paths, variable names, or internal logic patterns.
🔧 Fix: Abstracted error messages away to a generic message when exposing an HTTP response via `raise HTTPException()`, and logged the original exception string via `logger.error()` safely on the server side instead. Added a `logger.error` call where it was missing in `rules.py`.
✅ Verification: Ran `uv run python -m compileall .` in `apps/api` and `pnpm lint`, `pnpm test` in `apps/web` respectively to ensure tests pass. No exceptions are passed directly to `HTTPException` detail strings. Added a journal entry about the learning.

---
*PR created automatically by Jules for task [15931481814906814603](https://jules.google.com/task/15931481814906814603) started by @osama-ata*